### PR TITLE
Update metal-tools-soy to 4.0.0 and release 4.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "metal-cli",
-  "version": "3.0.0",
+  "version": "4.0.0",
   "description": "Command line tools for metal (e.g. build)",
   "license": "BSD",
   "repository": "metal/metal-cli",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "metal-tools-build-amd": "^3.0.0",
     "metal-tools-build-globals": "^2.0.0",
     "metal-tools-build-jquery": "^2.0.0",
-    "metal-tools-soy": "^3.0.0",
+    "metal-tools-soy": "^4.0.0",
     "require-dir": "^0.3.0",
     "stream-consume": "^0.1.0",
     "vinyl-fs": "^2.2.1",


### PR DESCRIPTION
Hey @eduardolundgren, this will update `metal-tools-soy` to the recently released `4.0.0` version, and we'll publish `metal-cli@4.0.0` after that to make sure no-one runs into it accidentally.